### PR TITLE
fix black overlay not covering entire device on orientation change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ export class ReactNativeModal extends Component {
           ref={ref => (this.backdropRef = ref)}
           style={[
             styles.backdrop,
-            { backgroundColor: backdropColor, width: deviceWidth, height: deviceHeight },
+            { backgroundColor: backdropColor },
           ]}
         />
         <View

--- a/src/index.style.js
+++ b/src/index.style.js
@@ -2,6 +2,7 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   backdrop: {
+    flex: 1,
     position: 'absolute',
     top: 0,
     bottom: 0,


### PR DESCRIPTION
Issue: Black background overlay did not cover entire screen on device orientation change from Portrait to Landscape

This fixes the issue mentioned in #27. Let me know if it is ok @mmazzarolo 