### PR TITLE
Bump react-native-animatable

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "prop-types": "15.5.10",
-    "react-native-animatable": "^1.2.0"
+    "react-native-animatable": "^1.2.3"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
react-native-animatable recently upgraded to fix the React.PropTypes deprecation warning. 

This PR upgrades `react-native-animatable` to that fixed version. Fixing all libraries that depend on it. 