### PR TITLE
fix setState can only update a mounted or mounting Component warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,10 @@ export class ReactNativeModal extends Component {
     DeviceEventEmitter.addListener('didUpdateDimensions', this._handleDimensionsUpdate);
   }
 
+  componentWillUnmount() {
+    DeviceEventEmitter.removeListener('didUpdateDimensions', this._handleDimensionsUpdate);
+  }
+
   componentDidUpdate(prevProps, prevState) {
     // On modal open request, we slide the view up and fade in the backdrop
     if (this.state.isVisible && !prevState.isVisible) {


### PR DESCRIPTION
when orientation change during a modal unmount, it will show the warning.

And it will be leak if we do not remove after component unmount