### PR TITLE
Remove 'declare' word

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,7 +20,7 @@ declare module 'react-native-modal' {
     style?: StyleProp<ViewStyle>
   }
 
-  declare class Modal extends Component<ModalProps> {}
+  class Modal extends Component<ModalProps> {}
 
   export default Modal
 }


### PR DESCRIPTION
Typescript does not like the use of the word 'declare' in typings files. This file works correctly when it is removed though.