### PR TITLE
Fix avoidKeyboard feature for Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   DeviceEventEmitter,
   TouchableWithoutFeedback,
   KeyboardAvoidingView,
+  Platform
 } from 'react-native';
 import PropTypes from 'prop-types';
 import {
@@ -253,7 +254,7 @@ export class ReactNativeModal extends Component {
 
         {avoidKeyboard && (
           <KeyboardAvoidingView
-            behavior={'padding'}
+            behavior={Platform.OS === 'ios' ? 'padding' : null}
             pointerEvents={'box-none'}
             style={computedStyle.concat([{ margin: 0 }])}
           >


### PR DESCRIPTION
This feature was working weirdly for me ([issue](https://github.com/facebook/react-native/issues/11681))