### PR TITLE
Allow Backdrop Opacity Updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,12 @@ export class ReactNativeModal extends Component {
     ) {
       this._buildAnimations(nextProps);
     }
+    if (this.props.backdropOpacity !== nextProps.backdropOpacity && this.backdropRef) {
+      this.backdropRef.transitionTo(
+        { opacity: nextProps.backdropOpacity },
+        this.props.backdropTransitionInTiming
+      );
+    }
   }
 
   componentWillMount() {


### PR DESCRIPTION
Enables the ability to update the backdropOpacity of an open modal, as discussed in https://github.com/react-native-community/react-native-modal/issues/95