### PR TITLE
Swipe feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ For a more complex example take a look at the `/example` directory.
 | backdropOpacity | number | 0.70 | The backdrop opacity when the modal is visible |
 | backdropTransitionInTiming | number | 300 | The backdrop show timing (in ms) |
 | backdropTransitionOutTiming | number | 300 | The backdrop hide timing (in ms) |
+| children | node | **REQUIRED** | The modal content |
+| isVisible | bool | **REQUIRED** | Show the modal? |
 | onBackButtonPress | func | () => null | Called when the Android back button is pressed |
 | onBackdropPress | func | () => null | Called when the backdrop is pressed |
-| useNativeDriver | bool | false | Define if animations should use [native driver](https://facebook.github.io/react-native/docs/animated.html#using-the-native-driver) |
-| isVisible | bool | **REQUIRED** | Show the modal? |
-| children | node | **REQUIRED** | The modal content |
-| onModalShow | func | () => null | Called when the modal is completely visible |
 | onModalHide | func | () => null | Called when the modal is completely hidden |
-| style | any | null | Style applied to the modal |
+| onModalShow | func | () => null | Called when the modal is completely visible |
 | onSwipe | func | null | Called when the onSwipeTreshold has been reach |
-| onSwipeTreshold | number | 100 | Treshold that will trigger onSwipe |
-| swipeDirection | string | null | When set, enabled the swipe to close feature. Possible value ['up', 'down', 'left, 'right']
+| onSwipeTreshold | number | 100 | Threshold for calling onSwipe |
+| style | any | null | Style applied to the modal |
+| swipeDirection | string | null | When set, enables the swipe to close feature. Possible values ['up', 'down', 'left, 'right']
+| useNativeDriver | bool | false | Define if animations should use [native driver](https://facebook.github.io/react-native/docs/animated.html#using-the-native-driver) |
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An enhanced, animated and customizable react-native modal.
 - Customizable backdrop opacity, color and timing
 - Listeners for the modal animations ending
 - Resize itself correctly on device rotation
-- Swipe to close
+- Swipeable
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An enhanced, animated and customizable react-native modal.
 - Customizable backdrop opacity, color and timing
 - Listeners for the modal animations ending
 - Resize itself correctly on device rotation
+- Swipe to close
 
 ## Demo
 
@@ -128,6 +129,9 @@ For a more complex example take a look at the `/example` directory.
 | onModalShow | func | () => null | Called when the modal is completely visible |
 | onModalHide | func | () => null | Called when the modal is completely hidden |
 | style | any | null | Style applied to the modal |
+| onSwipe | func | null | Called when the onSwipeTreshold has been reach |
+| onSwipeTreshold | number | 100 | Treshold that will trigger onSwipe |
+| swipeDirection | string | null | When set, enabled the swipe to close feature. Possible value ['up', 'down', 'left, 'right']
 
 ## Frequently Asked Questions
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,8 @@ declare module 'react-native-modal' {
     onBackButtonPress?: () => void
     onBackdropPress?: () => void
     style?: StyleProp<ViewStyle>
+    swipeDirection: string,
+    swipeThreshold: number,
   }
 
   class Modal extends Component<ModalProps> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,9 +21,10 @@ declare module 'react-native-modal' {
     onModalHide?: () => void
     onBackButtonPress?: () => void
     onBackdropPress?: () => void
+    onSwipe?: () => void
+    onSwipeThreshold?: number,
     style?: StyleProp<ViewStyle>
-    swipeDirection: string,
-    swipeThreshold: number,
+    swipeDirection?: string,
   }
 
   class Modal extends Component<ModalProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -31,10 +31,6 @@ const isObject = obj => {
   return obj !== null && typeof obj === 'object';
 };
 
-const horizontalDirections = direction => {
-  return direction == 'right' || direction == 'left';
-}
-
 export class ReactNativeModal extends Component {
   static propTypes = {
     animationIn: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
@@ -56,7 +52,7 @@ export class ReactNativeModal extends Component {
     onSwipeThreshold: PropTypes.number,
     useNativeDriver: PropTypes.bool,
     style: PropTypes.any,
-    swipeDirection: PropTypes.string,
+    swipeDirection: PropTypes.oneOf(['up', 'down', 'left', 'right']),
   };
 
   static defaultProps = {
@@ -151,7 +147,7 @@ export class ReactNativeModal extends Component {
   _buildPanResponder = () => {
     let animEvt = null;
 
-    if (horizontalDirections(this.props.swipeDirection)) {
+    if (this.props.swipeDirection == 'right' || this.props.swipeDirection == 'left') {
       animEvt = Animated.event([null,{ dx : this.state.pan.x }]);
     }
     else {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   DeviceEventEmitter,
   TouchableWithoutFeedback,
   KeyboardAvoidingView,
+  Platform,
   PanResponder,
   Animated,
 } from 'react-native';
@@ -385,7 +386,7 @@ export class ReactNativeModal extends Component {
 
         {avoidKeyboard && (
           <KeyboardAvoidingView
-            behavior={'padding'}
+            behavior={Platform.OS === 'ios' ? 'padding' : null}
             pointerEvents={'box-none'}
             style={computedStyle.concat([{ margin: 0 }])}
           >

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,10 @@ export class ReactNativeModal extends Component {
         this.backdropRef.transitionTo({ opacity: this.props.backdropOpacity }, this.props.backdropTransitionInTiming);
         Animated.spring(
           this.state.pan,
-          { toValue: {x: 0, y: 0} }
+          {
+            toValue: {x: 0, y: 0},
+            bounciness: 0,
+          }
         ).start();
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,10 @@ export class ReactNativeModal extends Component {
   constructor(props) {
     super(props);
     this._buildAnimations(props);
+    if (this.state.isSwipeable) {
+      this.state = { ...this.state, pan: new Animated.ValueXY() };
+      this._buildPanResponder();
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -108,17 +112,17 @@ export class ReactNativeModal extends Component {
     ) {
       this._buildAnimations(nextProps);
     }
-    if (!this.props.swipeDirection && nextProps.swipeDirection) {
-      this.setState({ pan: new Animated.ValueXY() });
+    if (this.props.backdropOpacity !== nextProps.backdropOpacity && this.backdropRef) {
+      this.backdropRef.transitionTo(
+        { opacity: nextProps.backdropOpacity },
+        this.props.backdropTransitionInTiming
+      );
     }
   }
 
   componentWillMount() {
     if (this.props.isVisible) {
       this.setState({ isVisible: true });
-    }
-    if (this.state.isSwipeable) {
-      this._buildPanResponder();
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,6 @@ export class ReactNativeModal extends Component {
     onBackButtonPress: () => null,
     onSwipeThreshold: 100,
     useNativeDriver: false,
-    swipeDirection: null,
   };
 
   // We use an internal state for keeping track of the modal visibility: this allows us to keep
@@ -180,9 +179,9 @@ export class ReactNativeModal extends Component {
 
   _getAccDistancePerDirection = gestureState => {
     switch (this.props.swipeDirection) {
-      case 'top':
+      case 'up':
         return -gestureState.dy;
-      case 'bottom':
+      case 'down':
         return gestureState.dy;
       case 'right':
         return gestureState.dx;
@@ -200,10 +199,10 @@ export class ReactNativeModal extends Component {
     const draggedRight = dx > 0;
 
     switch (this.props.swipeDirection) {
-      case 'top':
+      case 'up':
         if (draggedUp) return true;
         break;
-      case 'bottom':
+      case 'down':
         if (draggedDown) return true;
         break;
       case 'right':
@@ -283,10 +282,10 @@ export class ReactNativeModal extends Component {
     if ( this.inSwipeClosingState ) {
       this.inSwipeClosingState = false;
       switch (this.props.swipeDirection) {
-        case 'top':
+        case 'up':
           animationOut = 'slideOutUp';
           break;
-        case 'bottom':
+        case 'down':
           animationOut = 'slideOutDown';
           break;
         case 'right':

--- a/src/index.js
+++ b/src/index.js
@@ -137,9 +137,8 @@ export class ReactNativeModal extends Component {
     // On modal open request, we slide the view up and fade in the backdrop
     if (this.props.isVisible && !prevProps.isVisible) {
       this._open();
-    }
-    // On modal close request, we slide the view down and fade out the backdrop
-    else if (!this.props.isVisible && prevProps.isVisible) {
+    } else if (!this.props.isVisible && prevProps.isVisible) {
+      // On modal close request, we slide the view down and fade out the backdrop
       this._close();
     }
   }
@@ -149,8 +148,7 @@ export class ReactNativeModal extends Component {
 
     if (this.props.swipeDirection == 'right' || this.props.swipeDirection == 'left') {
       animEvt = Animated.event([null,{ dx : this.state.pan.x }]);
-    }
-    else {
+    } else {
       animEvt = Animated.event([null,{ dy : this.state.pan.y }]);
     }
 
@@ -258,7 +256,7 @@ export class ReactNativeModal extends Component {
     this.transitionLock = true;
     this.backdropRef.transitionTo(
       { opacity: this.props.backdropOpacity },
-      this.props.backdropTransitionInTiming,
+      this.props.backdropTransitionInTiming
     );
 
     // This is for reset the pan position, if not modal get stuck
@@ -272,8 +270,7 @@ export class ReactNativeModal extends Component {
       this.transitionLock = false;
       if (!this.props.isVisible) {
         this._close();
-      }
-      else {
+      } else {
         this.props.onModalShow();
       }
     });
@@ -308,8 +305,7 @@ export class ReactNativeModal extends Component {
       this.transitionLock = false;
       if (this.props.isVisible) {
         this._open();
-      }
-      else {
+      } else {
         this.setState({ isVisible: false });
         this.props.onModalHide();
       }
@@ -358,7 +354,6 @@ export class ReactNativeModal extends Component {
         style={[panPosition, computedStyle]}
         pointerEvents={'box-none'}
         useNativeDriver={useNativeDriver}
-        onLayout={this._containerViewOnLayout}
         {...otherProps}
       >
         {children}
@@ -388,17 +383,17 @@ export class ReactNativeModal extends Component {
           />
         </TouchableWithoutFeedback>
 
-          {avoidKeyboard && (
-            <KeyboardAvoidingView
-              behavior={'padding'}
-              pointerEvents={'box-none'}
-              style={computedStyle.concat([{ margin: 0 }])}
-            >
-              {containerView}
-            </KeyboardAvoidingView>
-          )}
+        {avoidKeyboard && (
+          <KeyboardAvoidingView
+            behavior={'padding'}
+            pointerEvents={'box-none'}
+            style={computedStyle.concat([{ margin: 0 }])}
+          >
+            {containerView}
+          </KeyboardAvoidingView>
+        )}
 
-          {!avoidKeyboard && containerView}
+        {!avoidKeyboard && containerView}
       </Modal>
     );
   }


### PR DESCRIPTION
You can now by setting `swipeDirection` swipe the modal in the given direction ('up', 'down', 'right' or 'left').

**New props:**
- `swipeDirection`: When set, enable to swipe the modal in the given direction.
- `onSwipeTreshold`: Treshold for calling onSwipe.
- `onSwipe`: Called when `onSwipeTreshold` has been reach.

**Other changes:**
- Update README (add doc)
- Order prop alphabetically 

**Example:**
```javascript
<Modal
  isVisible={isModalOpen}
  swipeDirection='right'
  onSwipeThreshold={200}
  onSwipe={() => this.setState({ isModalOpen: false })}
>
...
</Modal>

```