### PR TITLE
Workaround for the flashes when useNativeDriver={true}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ export class ReactNativeModal extends Component {
     backdropTransitionOutTiming: PropTypes.number,
     children: PropTypes.node.isRequired,
     isVisible: PropTypes.bool.isRequired,
+    hideModalContentWhileAnimating: PropTypes.bool,
     onModalShow: PropTypes.func,
     onModalHide: PropTypes.func,
     onBackButtonPress: PropTypes.func,
@@ -69,6 +70,7 @@ export class ReactNativeModal extends Component {
     onModalShow: () => null,
     onModalHide: () => null,
     isVisible: false,
+    hideModalContentWhileAnimating: false,
     onBackdropPress: () => null,
     onBackButtonPress: () => null,
     swipeThreshold: 100,
@@ -369,6 +371,7 @@ export class ReactNativeModal extends Component {
       panPosition = this.state.pan.getLayout();
     }
 
+    const _children = this.props.hideModalContentWhileAnimating && this.props.useNativeDriver &&!this.state.showContent ? <View /> : children;
     const containerView = (
       <View
         {...panHandlers}
@@ -378,7 +381,7 @@ export class ReactNativeModal extends Component {
         useNativeDriver={useNativeDriver}
         {...otherProps}
       >
-        {this.state.showContent ? children : <View />}
+        {_children}
       </View>
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ export class ReactNativeModal extends Component {
   // We store in the state the device width and height so that we can update the modal on
   // device rotation.
   state = {
+    showContent: true,
     isVisible: false,
     deviceWidth: Dimensions.get("window").width,
     deviceHeight: Dimensions.get("window").height,
@@ -102,7 +103,7 @@ export class ReactNativeModal extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (!this.state.isVisible && nextProps.isVisible) {
-      this.setState({ isVisible: true });
+      this.setState({ isVisible: true, showContent: true });
     }
     if (
       this.props.animationIn !== nextProps.animationIn ||
@@ -123,7 +124,7 @@ export class ReactNativeModal extends Component {
 
   componentWillMount() {
     if (this.props.isVisible) {
-      this.setState({ isVisible: true });
+      this.setState({ isVisible: true, showContent: true });
     }
   }
 
@@ -321,7 +322,13 @@ export class ReactNativeModal extends Component {
       if (this.props.isVisible) {
         this.open();
       } else {
-        this.setState({ isVisible: false });
+        this.setState({
+          showContent: false
+        }, () => {
+          this.setState({
+            isVisible: false
+          })
+        });
         this.props.onModalHide();
       }
     });
@@ -371,7 +378,7 @@ export class ReactNativeModal extends Component {
         useNativeDriver={useNativeDriver}
         {...otherProps}
       >
-        {children}
+        {this.state.showContent ? children : <View />}
       </View>
     );
 
@@ -390,7 +397,7 @@ export class ReactNativeModal extends Component {
             style={[
               styles.backdrop,
               {
-                backgroundColor: backdropColor,
+                backgroundColor: this.state.showContent ? backdropColor : 'transparent',
                 width: deviceWidth,
                 height: deviceHeight
               }


### PR DESCRIPTION
### Workaround
- add `showContent` to state for toggling the content in the modal
- add `hideModalContentWhileAnimating` to props for using this workaround when `useNativeDriver={true}`

### Credits
- proposal https://github.com/react-native-community/react-native-modal/issues/92#issuecomment-354796617 
- commit fo the fix https://github.com/Versus2017/react-native-modal/commit/05056652105aae0f01de0a09ce03956f06a5646d#diff-1fdf421c05c1140f6d71444ea2b27638

connect #92 