### PR TITLE
README Suggestions : Avoid Flashes Case on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The prop `onSwipe` allows you to handle this situation (remember to set `swipeDi
 
 Unfortunately this is a [know issue](https://github.com/react-native-community/react-native-modal/issues/92) that happens when `useNativeDriver=true` and must still be solved.  
 In the meanwhile as a workaround you can set the `hideModalContentWhileAnimating` prop to `true`: this seems to solve the issue.
+Also, do not assign a `backgroundColor` property directly to the Modal. Prefer to set it on the child container.
 
 ### The modal background doesn't animate properly
 


### PR DESCRIPTION
After the 'flashes' episode we had on `react-native-modal` (#92).
I found myself subject to some flashes when using the component on iOS.

And i've found out it was caused because i was setting a backgroundColor `white` directly to my Modal component instead of the child 'container'.

In order to avoid that someone else reproduce this mistake and goes through the same process, i'd like to suggest that we add a text to the READMe.md file to tell the user not to set `backgroundColor` style to the `Modal` as it will cause flashes on iOS.