### PR TITLE
corrected ModalProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,11 +23,12 @@ declare module "react-native-modal" {
     onBackButtonPress?: () => void;
     onBackdropPress?: () => void;
     onSwipe?: () => void;
-    onSwipeThreshold?: number;
+    swipeThreshold?: number;
     style?: StyleProp<ViewStyle>;
-    swipeDirection?: string;
+    swipeDirection?: "up" | "down" | "left" | "right";
     scrollTo?: () => void;
     scrollOffset?: number;
+    scrollOffsetMax?: number;
   }
 
   class Modal extends Component<ModalProps> {}


### PR DESCRIPTION
I fixed some properties on ModalProps for using Modal with typescript.

### Added

- `scrollOffsetMax`

### Changes

- `onSwipeThreshold` -> `swipeThreshold`
  - maybe `onSwipeThreshold` is old name.
- `swipeDirection` type
  - for type safety
