### PR TITLE
Added rotation support on iOS.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ declare module "react-native-modal" {
     scrollTo?: () => void;
     scrollOffset?: number;
     scrollOffsetMax?: number;
+    supportedOrientations?: "portrait" | "portrait-upside-down" | "landscape" | "landscape-left" | "landscape-right";
   }
 
   class Modal extends Component<ModalProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ class ReactNativeModal extends Component {
     style: PropTypes.any,
     scrollTo: PropTypes.func,
     scrollOffset: PropTypes.number,
-    scrollOffsetMax: PropTypes.number
+    scrollOffsetMax: PropTypes.number,
+    supportedOrientations: PropTypes.oneOf(['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right'])
   };
 
   static defaultProps = {
@@ -80,7 +81,8 @@ class ReactNativeModal extends Component {
     useNativeDriver: false,
     scrollTo: null,
     scrollOffset: 0,
-    scrollOffsetMax: 0
+    scrollOffsetMax: 0,
+    supportedOrientations: ['portrait', 'landscape']
   };
 
   // We use an internal state for keeping track of the modal visibility: this allows us to keep


### PR DESCRIPTION
Added another property to the modal: `supportedOrientations`

This already exists as a property of the built in modal to react native. However, when using this library in TypeScript, it can't find that this is a valid prop for the modal. This adds it as a property, as well as a default rotation of `['portrait', 'landscape']`