### PR TITLE
Added support for multiple orientations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,7 @@ declare module "react-native-modal" {
     scrollTo?: () => void;
     scrollOffset?: number;
     scrollOffsetMax?: number;
-    supportedOrientations?: "portrait" | "portrait-upside-down" | "landscape" | "landscape-left" | "landscape-right";
+    supportedOrientations?: string[];
   }
 
   class Modal extends Component<ModalProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class ReactNativeModal extends Component {
     scrollTo: PropTypes.func,
     scrollOffset: PropTypes.number,
     scrollOffsetMax: PropTypes.number,
-    supportedOrientations: PropTypes.arrayOf(PropTypes.string),
+    supportedOrientations: PropTypes.arrayOf(PropTypes.oneOf(["portrait", "portrait-upside-down", "landscape", "landscape-left", "landscape-right"])),
   };
 
   static defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class ReactNativeModal extends Component {
     scrollTo: null,
     scrollOffset: 0,
     scrollOffsetMax: 0,
-    supportedOrientations: ['portrait', 'landscape']
+    supportedOrientations: ["portrait", "landscape"]
   };
 
   // We use an internal state for keeping track of the modal visibility: this allows us to keep

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class ReactNativeModal extends Component {
     scrollTo: PropTypes.func,
     scrollOffset: PropTypes.number,
     scrollOffsetMax: PropTypes.number,
-    supportedOrientations: PropTypes.oneOf(["portrait", "portrait-upside-down", "landscape", "landscape-left", "landscape-right"])
+    supportedOrientations: PropTypes.arrayOf(PropTypes.string),
   };
 
   static defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class ReactNativeModal extends Component {
     scrollTo: PropTypes.func,
     scrollOffset: PropTypes.number,
     scrollOffsetMax: PropTypes.number,
-    supportedOrientations: PropTypes.oneOf(['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right'])
+    supportedOrientations: PropTypes.oneOf(["portrait", "portrait-upside-down", "landscape", "landscape-left", "landscape-right"])
   };
 
   static defaultProps = {


### PR DESCRIPTION
Previously, the `PropTypes.oneOf` would throw a warning as multiple orientations were being defined in the default props for `supportedOrientations` this PR updates it so that it can be an array of strings for valid orientations in a Modal.