### PR TITLE
Changes scrollTo type 

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,7 +26,7 @@ declare module "react-native-modal" {
     swipeThreshold?: number;
     style?: StyleProp<ViewStyle>;
     swipeDirection?: "up" | "down" | "left" | "right";
-    scrollTo?: () => void;
+    scrollTo?: (e: any) => void;
     scrollOffset?: number;
     scrollOffsetMax?: number;
     supportedOrientations?: string[];


### PR DESCRIPTION
**Current behaviour:**
scrollTo prop has type 
`() => void;`
in index.d.ts.

**Problem**
This cause a type error when being called with an argument, since scrollTo takes in a parameter.

**Solution**
this should be 
`(e: any) => void;`
because the function is called with an argument containing the offset.