### PR TITLE
feat(typescript): Allow strict use of supported orientations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ declare module "react-native-modal" {
   import { StyleProp, ViewStyle } from "react-native";
 
   type AnimationConfig = string | { from: Object; to: Object };
+  type Orientation = "portrait" | "portrait-upside-down" | "landscape" | "landscape-left" | "landscape-right";
 
   export interface ModalProps {
     animationIn?: AnimationConfig;
@@ -29,7 +30,7 @@ declare module "react-native-modal" {
     scrollTo?: (e: any) => void;
     scrollOffset?: number;
     scrollOffsetMax?: number;
-    supportedOrientations?: string[];
+    supportedOrientations?: Orientation[];
   }
 
   class Modal extends Component<ModalProps> {}


### PR DESCRIPTION
The change made in https://github.com/react-native-community/react-native-modal/pull/181 to the typescript allows the user to pass any string values to `supportedOrientations`.

The example below compiles in typescript:
```jsx
<Modal supportedOrientations={['as', 'as']} />
```

This PR fixes the type and only allows orientation strings.