### PR TITLE
Fix wrong assigned deviceWidth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -427,7 +427,7 @@ class ReactNativeModal extends Component {
       style,
       ...otherProps
     } = this.props;
-    const deviceWidth = deviceHeightProp || this.state.deviceWidth;
+    const deviceWidth = deviceWidthProp || this.state.deviceWidth;
     const deviceHeight = deviceHeightProp || this.state.deviceHeight;
 
     const computedStyle = [


### PR DESCRIPTION
When I applied `deviceWidth` and `deviceHegith` props to fix android screen dimension problem, I found that the width of the modal is something wrong.
The problem is that the `deviceWidth` is assigned to the wrong value! I think it works well from now on.