### PR TITLE
Update README for adding eumij-modal-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,23 @@ That said, I would strongly advice against using multiple modals at the same tim
 
 Take a look at [react-native-animatable](https://github.com/oblador/react-native-animatable) to see the dozens of animations available out-of-the-box. You can also pass in custom animation definitions and have them automatically register with react-native-animatable. For more information on creating custom animations, see the react-native-animatable [animation definition schema](https://github.com/oblador/react-native-animatable#animation-definition-schema).
 
+## Introduce eumji-modal-pattern to handle multiple modals in project
+
+If you handle multiple modals in your project, Your project will be so messy like below.
+
+```
+render() {
+  return (
+     <Modal>...</Modal>
+     <Modal>...</Modal>
+     <Modal>...</Modal>
+     <Modal>...</Modal>
+  );
+}
+```
+
+To solve this troublesome, I would like to introduce the [`eumji-modal-pattern`](https://github.com/7772/eumji-modal-pattern). This pattern would help you to handle multiple modals without adding many code lines in your client side using Higer-Order-Component.
+
 ## Acknowledgements
 
 Thanks [@oblador](https://github.com/oblador) for react-native-animatable, [@brentvatne](https://github.com/brentvatne) for the npm namespace and to anyone who contributed to this library!


### PR DESCRIPTION
In react native, It is difficult to write clean code in render method if you are using multiple modals.

```
render () {
  return (
    <Modal>...</Modal>
    <Modal>...</Modal>
    <Modal>...</Modal>
    <Modal>...</Modal>
  );
}
```

In addition to above, there are also [problems](https://github.com/7772/eumji-modal-pattern/blob/master/docs/problems.md).

Do you agree?

I considered the new pattern to handle multiple modals without adding code lines in render method by using higher-order-function.

Please read [eumji-modal-pattern](https://github.com/7772/eumji-modal-pattern) and Add the contents in README.md if you agreed.

Thanks.


ps.`Eumji Modal Pattern` has recommended react-native-modal.