### PR TITLE
Use getTranslateTransform instead of getLayout when useNativeDriver=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The prop `onSwipe` allows you to handle this situation (remember to set `swipeDi
   </View>
 </Modal>
 ```
+Note that when using `useNativeDriver={true}` the modal won't drag correctly. This is a [known issue](https://github.com/react-native-community/react-native-modal/issues/163#issuecomment-409760695).
 
 ### The modal flashes in a weird way when animating
 

--- a/src/index.js
+++ b/src/index.js
@@ -449,7 +449,14 @@ class ReactNativeModal extends Component {
     let panPosition = {};
     if (this.state.isSwipeable) {
       panHandlers = { ...this.panResponder.panHandlers };
-      panPosition = this.state.pan.getLayout();
+
+      if (useNativeDriver) {
+        panPosition = {
+            transform: this.state.pan.getTranslateTransform()
+        };
+      } else {
+        panPosition = this.state.pan.getLayout();
+      }
     }
 
     const _children =


### PR DESCRIPTION
This is a less than ideal temporary fix for https://github.com/react-native-community/react-native-modal/issues/163. There is no easy way at the moment to both use the native driver AND allow the modal to be dragged. Currently trying to drag a modal when using the native driver, you will get an error that the property "left" is not supported - this fix allows you to use `useNativeDriver` while allowing the user to swipe, although without the visual feedback of seeing the modal get dragged.

I'm finding the lack of drag visualization is acceptable given the performance boost of using the native driver. In the future it would be great to get the native driver working with drag visuals.