### PR TITLE
Add onModalWillShow and onModalWillHide callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ For a more complex example take a look at the `/example` directory.
 | isVisible                      | bool             | **REQUIRED**   | Show the modal?                                                                              |
 | onBackButtonPress              | func             | () => null     | Called when the Android back button is pressed                                               |
 | onBackdropPress                | func             | () => null     | Called when the backdrop is pressed                                                          |
+| onModalWillHide                | func             | () => null     | Called before the modal hide animation begins                                                |
 | onModalHide                    | func             | () => null     | Called when the modal is completely hidden                                                   |
+| onModalWillShow                | func             | () => null     | Called before the modal show animation begins                                                |
 | onModalShow                    | func             | () => null     | Called when the modal is completely visible                                                  |
 | onSwipe                        | func             | null           | Called when the `swipeThreshold` has been reached                                            |
 | scrollOffset                   | number           | 0              | When > 0, disables swipe-to-close, in order to implement scrollable content                  |

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,9 @@ class ReactNativeModal extends Component {
     hideModalContentWhileAnimating: PropTypes.bool,
     propagateSwipe: PropTypes.bool,
     onModalShow: PropTypes.func,
+    onModalWillShow: PropTypes.func,
     onModalHide: PropTypes.func,
+    onModalWillHide: PropTypes.func,
     onBackButtonPress: PropTypes.func,
     onBackdropPress: PropTypes.func,
     onSwipe: PropTypes.func,
@@ -83,9 +85,11 @@ class ReactNativeModal extends Component {
     backdropTransitionInTiming: 300,
     backdropTransitionOutTiming: 300,
     onModalShow: () => null,
+    onModalWillShow: () => null,
     deviceHeight: null,
     deviceWidth: null,
     onModalHide: () => null,
+    onModalWillHide: () => null,
     isVisible: false,
     hideModalContentWhileAnimating: false,
     propagateSwipe: PropTypes.false,
@@ -347,12 +351,13 @@ class ReactNativeModal extends Component {
 
     // This is for reset the pan position, if not modal get stuck
     // at the last release position when you try to open it.
-    // Could certainly be improve - no idea for the moment.
+    // Could certainly be improved - no idea for the moment.
     if (this.state.isSwipeable) {
       this.state.pan.setValue({ x: 0, y: 0 });
     }
 
     if (this.contentRef) {
+      this.props.onModalWillShow && this.props.onModalWillShow()
       this.contentRef[this.animationIn](this.props.animationInTiming).then(
         () => {
           this.transitionLock = false;
@@ -392,6 +397,7 @@ class ReactNativeModal extends Component {
     }
 
     if (this.contentRef) {
+      this.props.onModalWillHide && this.props.onModalWillHide()
       this.contentRef[animationOut](this.props.animationOutTiming).then(() => {
         this.transitionLock = false;
         if (this.props.isVisible) {


### PR DESCRIPTION
Currently there exist `onModalShow` and `onModalHide` which are triggered after the modal show and hide animations are complete, but I found it useful to have more granular callback at the beginning of the animations. In my case I was using this for haptic feedback, which didn't feel right after the animation was already complete.