### PR TITLE
hasBackdrop props

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For a more complex example take a look at the `/example` directory.
 | animationOut                   | string or object | 'slideOutDown'            | Modal hide animation                                                                         |
 | animationOutTiming             | number           | 300                       | Timing for the modal hide animation (in ms)                                                  |
 | avoidKeyboard                  | bool             | false                     | Move the modal up if the keyboard is open                                                    |
+| hasBackdrop                    | bool             | true                      | Render the backdrop                                                                          |
 | backdropColor                  | string           | 'black'                   | The backdrop background color                                                                |
 | backdropOpacity                | number           | 0.70                      | The backdrop opacity when the modal is visible                                               |
 | backdropTransitionInTiming     | number           | 300                       | The backdrop show timing (in ms)                                                             |

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ class ReactNativeModal extends Component {
     animationOut: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     animationOutTiming: PropTypes.number,
     avoidKeyboard: PropTypes.bool,
+    hasBackdrop: PropTypes.bool,
     backdropColor: PropTypes.string,
     backdropOpacity: PropTypes.number,
     backdropTransitionInTiming: PropTypes.number,
@@ -83,6 +84,7 @@ class ReactNativeModal extends Component {
     animationOut: "slideOutDown",
     animationOutTiming: 300,
     avoidKeyboard: false,
+    hasBackdrop: true,
     backdropColor: "black",
     backdropOpacity: 0.7,
     backdropTransitionInTiming: 300,
@@ -451,6 +453,7 @@ class ReactNativeModal extends Component {
       animationOut,
       animationOutTiming,
       avoidKeyboard,
+      hasBackdrop,
       backdropColor,
       backdropOpacity,
       backdropTransitionInTiming,
@@ -517,22 +520,24 @@ class ReactNativeModal extends Component {
         visible={this.state.isVisible}
         onRequestClose={onBackButtonPress}
         {...otherProps}>
-        <TouchableWithoutFeedback onPress={onBackdropPress}>
-          <View
-            ref={ref => (this.backdropRef = ref)}
-            useNativeDriver={true}
-            style={[
-              styles.backdrop,
-              {
-                backgroundColor: this.state.showContent
-                  ? backdropColor
-                  : "transparent",
-                width: deviceWidth,
-                height: deviceHeight,
-              },
-            ]}
-          />
-        </TouchableWithoutFeedback>
+        {hasBackdrop &&
+          <TouchableWithoutFeedback onPress={onBackdropPress}>
+            <View
+              ref={ref => (this.backdropRef = ref)}
+              useNativeDriver={true}
+              style={[
+                styles.backdrop,
+                {
+                  backgroundColor: this.state.showContent
+                    ? backdropColor
+                    : "transparent",
+                  width: deviceWidth,
+                  height: deviceHeight,
+                },
+              ]}
+            />
+          </TouchableWithoutFeedback> 
+        }
 
         {avoidKeyboard && (
           <KeyboardAvoidingView


### PR DESCRIPTION
In some cases the backdrop is not useful, even with `backdropOpacity: 0`, especially if using the component as a notification item that still allows background manipulation and will be dismissed with a timeout.