### PR TITLE
Add onModalWillShow and onModalWillHide props to typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,9 @@ declare module "react-native-modal" {
     propagateSwipe?: boolean;
     isVisible: boolean;
     onModalShow?: () => void;
+    onModalWillShow?: () => void;
     onModalHide?: () => void;
+    onModalWillHide?: () => void;
     onBackButtonPress?: () => void;
     onBackdropPress?: () => void;
     onSwipeStart?: () => void;


### PR DESCRIPTION
The 9.0.0 release included new props for `onModalWillShow` and `onModalWillHide` but it didn't include them in the typings.