### PR TITLE
enhanced backdrop opacity when swiping

### DIFF
--- a/example/Example.js
+++ b/example/Example.js
@@ -103,6 +103,8 @@ export default class Example extends Component {
         </Modal>
         <Modal
           isVisible={this.state.visibleModal === 5}
+          onSwipeComplete={() => this.setState({ visibleModal: null })}
+          swipeDirection={["up", "left", "right", "down"]}
           style={styles.bottomModal}>
           {this.renderModalContent()}
         </Modal>
@@ -114,7 +116,7 @@ export default class Example extends Component {
         <Modal
           isVisible={this.state.visibleModal === 7}
           onSwipeComplete={() => this.setState({ visibleModal: null })}
-          swipeDirection={["left"]}>
+          swipeDirection={["down"]}>
           {this.renderModalContent()}
         </Modal>
         <Modal


### PR DESCRIPTION
Noticed that backdrop opacity while swiping always rely on the deviceWidth (no matter the direction) and on the acceleration (which mean if you start at the very bottom, it doesn't fade out pretty well).

This is an intend to fix this behavior. I noticed we cannot really know the position of the content (as far as I know) which would have been the ideal behavior so instead we rely on the position of the finger which is way more precise than the initial implementation (through not perfect).

Reviews are welcome, from my tests this can pretty much ship on next.