### PR TITLE
Fix styling on scrollable modal example

### DIFF
--- a/example/Example.js
+++ b/example/Example.js
@@ -133,7 +133,7 @@ export default class Example extends Component {
               <View style={styles.scrollableModalContent1}>
                 <Text>Scroll me up</Text>
               </View>
-              <View style={styles.scrollableModalContent1}>
+              <View style={styles.scrollableModalContent2}>
                 <Text>Scroll me up</Text>
               </View>
             </ScrollView>


### PR DESCRIPTION
Hi! Was testing the example locally, looks like the example for the scrollable modal doesn't match the intended display. I'm basing this off of the example gif in the repo's readme, which has both styles, and that the `styles.scrollableModalContent2` is otherwise unused. 

This makes the code match the supplied example.

Expected:
<img width="167" alt="image" src="https://user-images.githubusercontent.com/25315679/55424704-dae8a300-554e-11e9-95e6-2cbb803714e5.png">
