### PR TITLE
Save lastScrollOffset onPanResponderRelease to prevent scrolling jitter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,9 +283,9 @@ class ReactNativeModal extends Component {
           bounciness: 0
         }).start();
 
-        this.lastScrollOffset = this.props.scrollOffset;
+        this.lastScrollOffset = Math.max(0, this.props.scrollOffset); // ignore negative offset, as it will scroll back to zero
         if (this.props.scrollOffset > this.props.scrollOffsetMax) {
-          this.lastScrollOffset = this.props.scrollOffset;
+          this.lastScrollOffset = this.props.scrollOffsetMax;
           this.props.scrollTo({
             y: this.props.scrollOffsetMax,
             animated: true


### PR DESCRIPTION
This PR seeks to fix the issue described here: https://github.com/react-native-community/react-native-modal/issues/290

It is currently a draft PR for a few reasons:
- I'm not entirely satisfied with my solution, though it works _nearly_ as expected
- The solution heavily assumes the user has a vertical scrollview with `swipeDirection: down`, and needs to be more robust
- This PR is currently branched off of `master` however I _believe_ there is some work in `next` or also `fix-scroll` where this PR might make more sense to merge

I am largely opening this for discussion/feedback as I seek to iron out this issue for our app, with the goal of getting this merged in once the solution feels complete.