### PR TITLE
Adjust gestureState based on offset when touch started

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -541,9 +541,13 @@ class ReactNativeModal extends Component {
     // which is necesseary to aid in reseting scrollOffsetWhenTouchStarted
     // if the user re-opens the modal with a scrollview in it
     if (this.props.scrollTo) {
-      this.props.scrollTo({ y: 0, animated: false });
+      if (this.props.scrollHorizontal) {
+        this.props.scrollTo({ x: 0, animated: false });
+      } else {
+        this.props.scrollTo({ y: 0, animated: false });
+      }
     }
-    
+
     let animationOut = this.animationOut;
 
     if (this.inSwipeClosingState) {


### PR DESCRIPTION
This PR aims to continue work on allowing a ScrollView inside a Modal. 

Additional features/fixes are:
- When the scrollview is able to scroll in the direction from `props.swipeDirection`, we want to allow that scroll to happen until we reach the beginning or the end of the scrollview, then pass the gesture back to the panResponder to begin the swipe-to-dismiss animation. Added the helper function `ableToScrollInSwipeDirection` which returns a `bool` 
- Further, the gestureState then needs to be altered by the scrollOffsetWhenTouchStarted, otherwise then the panResponder starts dismissing, the modal jumps immediately the distance of the gesture, rather than only the distance BEYOND what was scrolled
- added checks when the panResponder releases for if the scrollOffset is greater than max when scrollHorizontal = true, and also if it is less than zero in both scrolling directions
- added a `scrollTo: 0` on close, which aids to reset the prop `scrollOffset` should the user re-open the modal. (this could be handled by the user instead, but also seems more helpful than asking them to manage it)
- added a check each time the panResponder moves to see if the swipe direction has changed during the same simultaneous touch (which right now uses `dx, dy` but maybe the function `getSwipingDirection` should use `vx, vy` to get real-time direction rather than overall net direction?)

I think this is closer but not quite complete. Feel free to comment/patch/alter as necessary.