### PR TITLE
Fix issue with noBackdrop and swipe gestures.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -305,9 +305,11 @@ class ReactNativeModal extends Component {
           this.props.onSwipeCancel();
         }
 
-        this.backdropRef.transitionTo({
-          opacity: this.props.backdropOpacity
-        });
+        if (this.backdropRef) {
+          this.backdropRef.transitionTo({
+            opacity: this.props.backdropOpacity
+          });
+        }
 
         Animated.spring(this.state.pan, {
           toValue: { x: 0, y: 0 },


### PR DESCRIPTION
If a modal has no backdrop and and contains swipe gestures, if you gesture in any direction not listed in props will result in the following error.

Swiping down with these props results in the error below.
```
hasBackdrop={false}
swipeDirection="up"
```

<img width="523" alt="Screen Shot 2019-05-01 at 10 05 15" src="https://user-images.githubusercontent.com/2920419/57009982-5135ff00-6bfa-11e9-9f1b-4e40b458f379.png">