### PR TITLE
Fix useNativeDriver not being used on the backdrop animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -598,7 +598,7 @@ class ReactNativeModal extends Component {
       <TouchableWithoutFeedback onPress={onBackdropPress}>
         <animatable.View
           ref={ref => (this.backdropRef = ref)}
-          useNativeDriver={true}
+          useNativeDriver={useNativeDriver}
           style={[
             styles.backdrop,
             {


### PR DESCRIPTION
`useNativeDriver` is not being used on the backdrop animation. This can be an issue since some IOS devices does not handle the Native Driver correctly. IMO, the prop `useNativeDriver` should be used for both animations. 