### PR TITLE
fix: swipe propagation to children components, based on swipe direction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,8 +207,8 @@ class ReactNativeModal extends Component {
           const swipeAxisSensitivityThreshold = 30;
 
           if (
-            (['left', 'right'].includes(this.props.swipeDirection) && Math.abs(gestureState.dx) >= swipeAxisSensitivityThreshold) ||
-            (['up', 'down'].includes(this.props.swipeDirection) && Math.abs(gestureState.dy) >= swipeAxisSensitivityThreshold)
+            ((this.props.swipeDirection === 'left' || this.props.swipeDirection === 'right') && Math.abs(gestureState.dx) >= swipeAxisSensitivityThreshold) ||
+            ((this.props.swipeDirection === 'up' || this.props.swipeDirection === 'down') && Math.abs(gestureState.dy) >= swipeAxisSensitivityThreshold)
           ) {
 
             if (this.props.onSwipeStart) {

--- a/src/index.js
+++ b/src/index.js
@@ -202,28 +202,32 @@ class ReactNativeModal extends Component {
 
     this.panResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => {
-        // Use propagateSwipe to allow inner content to scroll. See PR:
-        // https://github.com/react-native-community/react-native-modal/pull/246
-        if (!this.props.propagateSwipe) {
-          // The number "4" is just a good tradeoff to make the panResponder
-          // work correctly even when the modal has touchable buttons.
-          // For reference:
-          // https://github.com/react-native-community/react-native-modal/pull/197
-          const shouldSetPanResponder =
-            Math.abs(gestureState.dx) >= 4 || Math.abs(gestureState.dy) >= 4;
-          if (shouldSetPanResponder && this.props.onSwipeStart) {
-            this.props.onSwipeStart();
+
+          if (
+            (['left', 'right'].includes(this.props.swipeDirection) && Math.abs(gestureState.dx) >= 10) ||
+            (['up', 'down'].includes(this.props.swipeDirection) && Math.abs(gestureState.dy) >= 10)
+          ) {
+
+            if (this.props.onSwipeStart) {
+              this.props.onSwipeStart();
+            }
+
+            this.currentSwipingDirection = this.getSwipingDirection(gestureState);
+            animEvt = this.createAnimationEventForSwipe();
+
+            return true;
+
           }
 
-          this.currentSwipingDirection = this.getSwipingDirection(gestureState);
-          animEvt = this.createAnimationEventForSwipe();
-          return shouldSetPanResponder;
-        }
-      },
+          return false;
+
+        },
       onStartShouldSetPanResponder: () => {
-        if (this.props.scrollTo && this.props.scrollOffset > 0) {
+
+        if (this.props.propagateSwipe || this.props.scrollTo && this.props.scrollOffset > 0) {
           return false; // user needs to be able to scroll content back up
         }
+
         if (this.props.onSwipeStart) {
           this.props.onSwipeStart();
         }
@@ -231,6 +235,7 @@ class ReactNativeModal extends Component {
         // Cleared so that onPanResponderMove can wait to have some delta
         // to work with
         this.currentSwipingDirection = null;
+
         return true;
       },
       onPanResponderMove: (evt, gestureState) => {

--- a/src/index.js
+++ b/src/index.js
@@ -203,9 +203,12 @@ class ReactNativeModal extends Component {
     this.panResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => {
 
+          // The minimum distance a swipe must cover over an axis before it registers as a swipe in that direction
+          const swipeAxisSensitivityThreshold = 30;
+
           if (
-            (['left', 'right'].includes(this.props.swipeDirection) && Math.abs(gestureState.dx) >= 10) ||
-            (['up', 'down'].includes(this.props.swipeDirection) && Math.abs(gestureState.dy) >= 10)
+            (['left', 'right'].includes(this.props.swipeDirection) && Math.abs(gestureState.dx) >= swipeAxisSensitivityThreshold) ||
+            (['up', 'down'].includes(this.props.swipeDirection) && Math.abs(gestureState.dy) >= swipeAxisSensitivityThreshold)
           ) {
 
             if (this.props.onSwipeStart) {


### PR DESCRIPTION
This fixes https://github.com/react-native-community/react-native-modal/issues/236 but it needs further testing and review from other people before merging.

The main issue is that `onStartShouldSetPanResponder` always catches gestures when `scrollTo` and `scrollOffset` are not set, which means `onMoveShouldSetPanResponder` (which is where `propagateSwipe` kicks in) is not getting called. Additionally we need to check if the current gesture exceeds the threshold _in the axis of the modal's swipeDirection_, not just universally. I found that a threshold of `30` worked better than `4` when testing this PR.

Edit: `30` seems like a good threshold.