### PR TITLE
Pass swiping direction parameter in onSwipeComplete callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -289,7 +289,9 @@ class ReactNativeModal extends Component {
         ) {
           if (this.props.onSwipeComplete) {
             this.inSwipeClosingState = true;
-            this.props.onSwipeComplete();
+            this.props.onSwipeComplete({
+              swipingDirection: this.getSwipingDirection(gestureState),
+            });
             return;
           }
           // Deprecated. Remove later.


### PR DESCRIPTION
The idea is to receive the swiping direction in onSwipeComplete callback to be able to take diferent business decisions based on it.

Example:

Close modal when swiping to up or dowm and change the modal content when swiping to left or right.