### PR TITLE
fix: bundler error when running the Android example

### DIFF
--- a/example/android/app/src/main/java/com/modalexample/MainApplication.java
+++ b/example/android/app/src/main/java/com/modalexample/MainApplication.java
@@ -28,7 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected String getJSMainModuleName() {
-      return "index";
+      return "example/index";
     }
   };
 


### PR DESCRIPTION
# Overview

When trying to run the current Android example, the bundler throws the following error:

```
Error: Unable to resolve module `./index` from `/Users/kenyontu/github/react-native-modal/.`: The module `./index` could not be found from `/Users/kenyontu/github/react-native-modal/.`. Indeed, none of these files exist:
  * `/Users/kenyontu/github/react-native-modal/index(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`
  * `/Users/kenyontu/github/react-native-modal/index/index(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`
    at ModuleResolver.resolveDependency (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:163:15)
    at ResolutionRequest.resolveDependency (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/node-haste/DependencyGraph/ResolutionRequest.js:52:18)
    at DependencyGraph.resolveDependency (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/node-haste/DependencyGraph.js:273:16)
    at /Users/kenyontu/github/react-native-modal/node_modules/metro/src/lib/transformHelpers.js:261:42
    at Server.<anonymous> (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/Server.js:935:41)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/Server.js:73:24)
    at _next (/Users/kenyontu/github/react-native-modal/node_modules/metro/src/Server.js:93:9)
::ffff:127.0.0.1 - - [15/Jun/2019:07:05:01 +0000] "GET /index.delta\?platform=android&dev=true&minify=false HTTP/1.1" 500 - "-" "okhttp/3.12.1"
```

**Note**: The iOS example works fine.

# Test Plan

Steps to check the issue:
- Clone the master branch
- Install dependencies with `yarn install`
- Run `yarn start:android`

