### PR TITLE
Removed usage of componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,13 @@ class ReactNativeModal extends Component {
     supportedOrientations: ['portrait', 'landscape'],
   };
 
+  static getDerivedStateFromProps(nextProps,state){
+    if (!state.isVisible && nextProps.isVisible) {
+      return { isVisible: true, showContent: true };
+    }
+    return null;
+  }
+
   // We use an internal state for keeping track of the modal visibility: this allows us to keep
   // the modal visible during the exit animation, even if the user has already change the
   // isVisible prop to false.
@@ -142,11 +149,7 @@ class ReactNativeModal extends Component {
     }
   }
 
-  // TODO: Stop using componentWillReceiveProps
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!this.state.isVisible && nextProps.isVisible) {
-      this.setState({ isVisible: true, showContent: true });
-    }
+  componentDidUpdate(nextProps){
     if (
       this.props.animationIn !== nextProps.animationIn ||
       this.props.animationOut !== nextProps.animationOut


### PR DESCRIPTION
# Overview

React Native kicks out a warning every time the modal is opened due to its usage of the `UNSAFE_componentWillReceiveProps` life-cycle hook. All I have done here is replace it with `getDerivedStateFromProps` to update `isVisible` and `showContent` appropriately, and `componentDidUpdate` to kick off the side-effects.

# Test Plan

All of the code is the same, with the only difference being that the life-cycle hooks have been updated to non-deprecated ones. I tested the changes using the example app and everything appeared to be identical to `componentWillReceiveProps`.
