### PR TITLE
Allow a fully customizable custom back drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ You need to specify the size of your custom backdrop component. You can also mak
 </Modal>
 ```
 
+### The custom backdrop doesn't dismiss the modal on press
+
+You can provide an event handler to the custom backdrop element to dismiss the modal. The prop `onBackdropPress` is not supported for a custom backdrop.
+
+```javascript
+<Modal
+  isVisible={this.state.isVisible}
+  customBackdrop={
+    <TouchableWithoutFeedback onPress={dismissModalHandler}>
+      <View style={{ flex: 1 }} />
+    </TouchableWithoutFeedback>
+  }
+/>
+
+```
+
 ## Available animations
 
 Take a look at [react-native-animatable](https://github.com/oblador/react-native-animatable) to see the dozens of animations available out-of-the-box. You can also pass in custom animation definitions and have them automatically register with react-native-animatable. For more information on creating custom animations, see the react-native-animatable [animation definition schema](https://github.com/oblador/react-native-animatable#animation-definition-schema).

--- a/src/index.js
+++ b/src/index.js
@@ -603,27 +603,32 @@ class ReactNativeModal extends Component {
     );
 
     const hasCustomBackdrop = React.isValidElement(customBackdrop);
+    
     const backdrop = (
+      <animatable.View
+        ref={ref => (this.backdropRef = ref)}
+        useNativeDriver={useNativeDriver}
+        style={[
+          styles.backdrop,
+          {
+            width: deviceWidth,
+            height: deviceHeight,
+          },
+          {
+            backgroundColor:
+              this.state.showContent && !hasCustomBackdrop
+                ? backdropColor
+                : 'transparent',
+          },
+        ]}
+      >
+        {hasCustomBackdrop && customBackdrop}
+      </animatable.View>
+    )
+
+    const touchableBackDrop = (
       <TouchableWithoutFeedback onPress={onBackdropPress}>
-        <animatable.View
-          ref={ref => (this.backdropRef = ref)}
-          useNativeDriver={useNativeDriver}
-          style={[
-            styles.backdrop,
-            {
-              width: deviceWidth,
-              height: deviceHeight,
-            },
-            {
-              backgroundColor:
-                this.state.showContent && !hasCustomBackdrop
-                  ? backdropColor
-                  : 'transparent',
-            },
-          ]}
-        >
-          {hasCustomBackdrop && customBackdrop}
-        </animatable.View>
+          { backdrop }
       </TouchableWithoutFeedback>
     );
 
@@ -636,7 +641,8 @@ class ReactNativeModal extends Component {
             { zIndex: 2, opacity: 1, backgroundColor: 'transparent' },
           ]}
         >
-          {hasBackdrop && backdrop}
+          {!hasCustomBackdrop && hasBackdrop && touchableBackdrop}
+          {hasCustomBackdrop && hasBackdrop && backdrop}
           {containerView}
         </View>
       );

--- a/src/index.js
+++ b/src/index.js
@@ -626,7 +626,7 @@ class ReactNativeModal extends Component {
       </animatable.View>
     )
 
-    const touchableBackDrop = (
+    const touchableBackdrop = (
       <TouchableWithoutFeedback onPress={onBackdropPress}>
           { backdrop }
       </TouchableWithoutFeedback>


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->

<!-- Help us understand your motivation by explaining why you decided to make this change -->

We have an accessibility problem with the backdrop. When opening a modal with a backdrop, the backdrop becomes the first focused element on Android. This happens because TouchableWithoutFeedback wraps the backdrop.

If we are able to create a fully custom backdrop, we will have more control to work with accessibility issues.  

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
