### PR TITLE
fix: wrap KeyboardAvoidingView children with ScrollView for Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import {
   Platform,
   TouchableWithoutFeedback,
   View,
+  ScrollView,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import * as animatable from 'react-native-animatable';
@@ -666,11 +667,17 @@ class ReactNativeModal extends Component {
 
         {avoidKeyboard && (
           <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : null}
+            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
             pointerEvents="box-none"
             style={computedStyle.concat([{ margin: 0 }])}
           >
-            {containerView}
+            {Platform.OS === 'android' ? (
+              <ScrollView showsVerticalScrollIndicator={false}>
+                {containerView}
+              </ScrollView>
+            ) : (
+              containerView
+            )}
           </KeyboardAvoidingView>
         )}
 


### PR DESCRIPTION
This PR fixes https://github.com/react-native-community/react-native-modal/issues/344.

As long as it eliminates problem with keyboard avoiding, it also introduces ScrollView as additional wrapper around containerView for Android.

I didn't notice any impact on styling, but it's quite likely it may have some, so that part is worth testing.

If you notice anything that can be improved while testing, please let me know!

![demo-gif](https://user-images.githubusercontent.com/36057162/64898928-5ff0f000-d689-11e9-8774-103512f2fb1b.gif)
