### PR TITLE
Configurable swipe completed depending on direction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,8 +296,9 @@ class ReactNativeModal extends Component {
       onPanResponderRelease: (evt, gestureState) => {
         // Call the onSwipe prop if the threshold has been exceeded on the right direction
         const accDistance = this.getAccDistancePerDirection(gestureState);
+
         if (
-          accDistance > this.props.swipeThreshold &&
+          accDistance > getThreshold(getSwipingDirection(gestureState)) &&
           this.isSwipeDirectionAllowed(gestureState)
         ) {
           if (this.props.onSwipeComplete) {
@@ -401,6 +402,15 @@ class ReactNativeModal extends Component {
     return Array.isArray(this.props.swipeDirection)
       ? this.props.swipeDirection.includes(direction)
       : this.props.swipeDirection === direction;
+  };
+
+  getThreshold = direction => {
+    //if is number return number else
+    if (typeof this.props.swipeThreshold === 'number') {
+      return this.props.swipeThreshold;
+    }
+
+    return this.props.swipeThreshold[direction];
   };
 
   isSwipeDirectionAllowed = ({dy, dx}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -298,7 +298,7 @@ class ReactNativeModal extends Component {
         const accDistance = this.getAccDistancePerDirection(gestureState);
 
         if (
-          accDistance > getThreshold(getSwipingDirection(gestureState)) &&
+          accDistance > this.getThreshold(getSwipingDirection(gestureState)) &&
           this.isSwipeDirectionAllowed(gestureState)
         ) {
           if (this.props.onSwipeComplete) {
@@ -405,7 +405,6 @@ class ReactNativeModal extends Component {
   };
 
   getThreshold = direction => {
-    //if is number return number else
     if (typeof this.props.swipeThreshold === 'number') {
       return this.props.swipeThreshold;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -298,7 +298,8 @@ class ReactNativeModal extends Component {
         const accDistance = this.getAccDistancePerDirection(gestureState);
 
         if (
-          accDistance > this.getThreshold(getSwipingDirection(gestureState)) &&
+          accDistance >
+            this.getThreshold(this.getSwipingDirection(gestureState)) &&
           this.isSwipeDirectionAllowed(gestureState)
         ) {
           if (this.props.onSwipeComplete) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,15 @@ class ReactNativeModal extends Component {
     onSwipeMove: PropTypes.func,
     onSwipeComplete: PropTypes.func,
     onSwipeCancel: PropTypes.func,
-    swipeThreshold: PropTypes.number,
+    swipeThreshold: PropTypes.oneOfType([
+      PropTypes.shape({
+        up: PropTypes.number,
+        down: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number,
+      }),
+      PropTypes.number,
+    ]),
     swipeDirection: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.oneOf(['up', 'down', 'left', 'right'])),
       PropTypes.oneOf(['up', 'down', 'left', 'right']),


### PR DESCRIPTION
I wanted to create a modal with configureable thresholds for swiping away (or not) in each direction. 

A real life example of what I've based this on is when you open the AirPods case and the battery modal appears. You can swipe it down and away but any other direction will result in the modal just bouncing.

This PR changes the swipeThreshold prop to either accept a number or an object of directions and thresholds:

```javascript
    swipeDirection={["up", "down"])
    swipeThreshold={{ down: 150 }}
```

This will mean the modal can only be dismissed by swiping down over the 150 unit threshold, swiping the modal up will mean it will bounce but not be dismissed;