### PR TITLE
Improve compatibility of tsconfig.json

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -1,4 +1,5 @@
-import React, {ReactNode} from 'react';
+import * as React from 'react';
+import {ReactNode} from 'react';
 import {
   Animated,
   DeviceEventEmitter,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
   "compilerOptions": {
     "lib": ["es5", "es6", "esnext.asynciterable"],
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "jsx": "react",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Turn off esModuleInterop, which not all consumers are guaranteed to have. This requires changing

```ts
import React from 'react'
```

to

```ts
import * as React from 'react'
```

Fixes #369

I discovered this on Definitely Typed, where `@types/react-native-dialog` fails to build. This also blocks updates to `@types/react` since all dependents of `@types/react` need to pass in order for CI to pass.

# Test Plan

This is a compile-only change, so if the build works, the change is good.
I will monitor Definitely Typed to make sure that `@types/react-native-dialog`, starts building again. 