### PR TITLE
Further improve compatibility of tsconfig.json

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -15,7 +15,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import * as animatable from 'react-native-animatable';
 import {Animation, CustomAnimation} from 'react-native-animatable';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
   ],
   "compilerOptions": {
     "lib": ["es5", "es6", "esnext.asynciterable"],
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "esModuleInterop": false,
     "jsx": "react",
     "moduleResolution": "node",


### PR DESCRIPTION
Turn off allowSyntheticDefaultImports, which not all consumers are guaranteed to have. This requires changing

```ts
import PropTypes from 'prop-types'
```

to

```ts
import * as PropTypes from 'prop-types'
```

This is a compile-only change, so if the build works, the change is good.
I missed the PropTypes reference until I tested @types/react-native-dialog and found that it still didn't build. Turns out `--allowSyntheticDefaultImports` has the same effect on imports as `--esModuleInterop`, and also needs to be turned off. Sorry for the double PRs.