### PR TITLE
Fixing custom animations for modals

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -566,7 +566,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     if (this.contentRef) {
       this.props.onModalWillShow && this.props.onModalWillShow();
-      this.contentRef[this.animationIn](this.props.animationInTiming).then(
+      this.contentRef.animate(this.animationIn, this.props.animationInTiming).then(
         () => {
           this.isTransitioning = false;
           if (!this.props.isVisible) {
@@ -608,7 +608,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     if (this.contentRef) {
       this.props.onModalWillHide && this.props.onModalWillHide();
-      this.contentRef[animationOut](this.props.animationOutTiming).then(() => {
+      this.contentRef.animate(animationOut, this.props.animationOutTiming).then(() => {
         this.isTransitioning = false;
         if (this.props.isVisible) {
           this.open();


### PR DESCRIPTION
# Overview

As the modal animations are based on the react-native-animatable, it should be possible to use custom animations. Yet an error is thrown if we configure one.
This PR fixes this issue.

# Test Plan

- Create a modal with custom animation and test it works
- Create a modal with a preconfigured animation and test it works.
