### PR TITLE
fix: improving scroll behavior when using scrollview/flatlist inside a modal

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -323,8 +323,19 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
         return false;
       },
-      onStartShouldSetPanResponder: () => {
-        if (this.props.scrollTo && this.props.scrollOffset > 0) {
+      onStartShouldSetPanResponder: (e: any) => {
+        const hasScrollableView =
+          e._dispatchInstances &&
+          e._dispatchInstances.some((instance: any) =>
+            /scrollview|flatlist/i.test(instance.type),
+          );
+
+        if (
+          hasScrollableView &&
+          this.props.propagateSwipe &&
+          this.props.scrollTo &&
+          this.props.scrollOffset > 0
+        ) {
           return false; // user needs to be able to scroll content back up
         }
         if (this.props.onSwipeStart) {


### PR DESCRIPTION
# Overview

I didn't get the modal with a scrollview or flatlist inside to work correctly. Especially if you also want to use the modal swipe-to-dismiss action. So I played around with it and came up with a (possible) fix. It solved it for me, at least. 

Maybe there is another way and this isn't necessary, I'm not sure.

# Test Plan

Tested it on android + ios. I've also added Detox E2E tests and Github Actions CI for it. This is the repository: https://github.com/reime005/ReactNativeModalTester

