### PR TITLE
[Types] Add translucent Prop to interface

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -94,6 +94,7 @@ export interface ModalProps extends ViewProps {
   scrollOffset: number;
   scrollOffsetMax: number;
   scrollHorizontal: boolean;
+  statusBarTranslucent?: boolean;
   supportedOrientations?: Orientation[];
 }
 


### PR DESCRIPTION
# Overview
React Native 0.62.x modal comes with new prop named `statusBarTranslucent`

- Add `statusBarTranslucent` prop to `ModalProps`

# Test Plan
n/a
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
