### PR TITLE
Avoid setting duplicated testID

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -729,6 +729,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
       ...otherProps
     } = this.props;
 
+    const {testID, ...containerProps} = otherProps;
     const computedStyle = [
       {margin: this.getDeviceWidth() * 0.05, transform: [{translateY: 0}]},
       styles.content,
@@ -766,7 +767,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         style={[panPosition, computedStyle]}
         pointerEvents="box-none"
         useNativeDriver={useNativeDriver}
-        {...otherProps}>
+        {...containerProps}>
         {_children}
       </animatable.View>
     );


### PR DESCRIPTION
When testing a component that uses `react-native-modal` using the `testID` prop, the `testID` is set in the Modal component and also in the container view leading to a duplicated `testID`.
This makes things tricky when using any of the recommended [test libraries](https://reactnative.dev/docs/testing-overview#component-tests) since querying by that `testID` finds two native elements instead of only one.

A possible solution would be to assign the `testID` only to the Modal component since someone using this package will have control over the content of the Modal and can set a different `testID` if they like.

This change should not affect the current behavior in any way.